### PR TITLE
build: automatically apply PR labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+cli:
+- changed-files:
+  - any-glob-to-any-file: cli/**
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file: docs/**
+
+🖥️web:
+- changed-files:
+  - any-glob-to-any-file: web/**
+
+📱mobile:
+- changed-files:
+  - any-glob-to-any-file: mobile/**
+
+🗄️server:
+- changed-files:
+  - any-glob-to-any-file: server/**
+
+🧠machine-learning:
+- changed-files:
+  - any-glob-to-any-file: machine-learning/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Motivation
----------
For me as a new contributor it is frustrating to submit a PR and it will always fail. Even worse: I have to wait for another contributor with more power to assign the label for me.

This will improve developer experience, as some of the labels can be assigned automatically based on changed files.

How to test
-----------
1. Merge this PR
2. Submit a couple of PRs with changes in the respective directories
3. Labels should be automatically applied